### PR TITLE
Context aware element validation

### DIFF
--- a/configsuite/config.py
+++ b/configsuite/config.py
@@ -151,15 +151,13 @@ class ConfigSuite(object):
 
         Pair = collections.namedtuple("KeyValuePair", ["key", "value"])
         return tuple(
-            sorted(
-                [
-                    Pair(
-                        self._build_snapshot(key, key_schema),
-                        self._build_snapshot(value, value_schema),
-                    )
-                    for key, value in config.items()
-                ]
-            )
+            [
+                Pair(
+                    self._build_snapshot(key, key_schema),
+                    self._build_snapshot(value, value_schema),
+                )
+                for key, value in config.items()
+            ]
         )
 
     def _build_snapshot(self, config, schema):

--- a/configsuite/meta_keys.py
+++ b/configsuite/meta_keys.py
@@ -26,6 +26,7 @@ class MetaKeys(enum.Enum):
     Item = "item"
     Required = "required"
     ElementValidators = "element_validators"
+    ContextValidators = "context_validators"
     Key = "key"
     Value = "value"
     Description = "description"

--- a/configsuite/schema.py
+++ b/configsuite/schema.py
@@ -25,13 +25,26 @@ from configsuite import MetaKeys as MK
 from configsuite import types
 
 
+@configsuite.validator_msg("Collections cannot be context validated")
+def _context_basic_only(elem):
+    return not (
+        isinstance(elem[MK.Type], types.Collection) and MK.ContextValidators in elem
+    )
+
+
 _META_SCHEMA = {
     MK.Type: types.NamedDict,
+    MK.ElementValidators: (_context_basic_only,),
     MK.Content: {
         MK.Type: {MK.Type: types.Type},
         MK.Required: {MK.Type: types.Bool, MK.Required: False},
         MK.Description: {MK.Type: types.String, MK.Required: False},
         MK.ElementValidators: {
+            MK.Type: types.List,
+            MK.Required: False,
+            MK.Content: {MK.Item: {MK.Type: types.Callable}},
+        },
+        MK.ContextValidators: {
             MK.Type: types.List,
             MK.Required: False,
             MK.Content: {MK.Item: {MK.Type: types.Callable}},

--- a/configsuite/types.py
+++ b/configsuite/types.py
@@ -44,7 +44,7 @@ class BooleanResult(object):
 
     @property
     def msg(self):
-        msg_fmt = "{} is {} on input {}"
+        msg_fmt = "{} is {} on input '{}'"
         return msg_fmt.format(self._msg, "true" if self else "false", self._input)
 
     def __repr__(self):
@@ -80,9 +80,19 @@ def validator_msg(msg):
             def msg(self):
                 return self._msg
 
+            def _build_argument_str(self, *args, **kwargs):
+                elems = [str(arg) for arg in args]
+                elems += [
+                    "{}={}".format(str(key), str(value))
+                    for key, value in kwargs.items()
+                ]
+
+                return ", ".join(elems)
+
             def __call__(self, *args, **kwargs):
                 res = self._function(*args, **kwargs)
-                return BooleanResult(res, self._msg, str(*args) + str(**kwargs))
+                argument_str = self._build_argument_str(*args, **kwargs)
+                return BooleanResult(res, self._msg, argument_str)
 
         return Wrapper(function, msg)
 

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -23,3 +23,4 @@ from . import pets
 from . import candy_bag
 from . import candidate
 from . import hero
+from . import transactions

--- a/tests/data/transactions.py
+++ b/tests/data/transactions.py
@@ -1,0 +1,105 @@
+"""Copyright 2019 Equinor ASA and The Netherlands Organisation for
+Applied Scientific Research TNO.
+
+Licensed under the MIT license.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the conditions stated in the LICENSE file in the project root for
+details.
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+"""
+
+
+import collections
+
+import configsuite
+from configsuite import MetaKeys as MK
+from configsuite import types
+
+
+@configsuite.validator_msg("Currency rate should not be negative")
+def _positive_rate(rate):
+    return rate > 0
+
+
+@configsuite.validator_msg("Amount should not be negative")
+def _positive_amount(amount):
+    return amount > 0
+
+
+@configsuite.validator_msg("Should be defined currency")
+def _is_currency(elem, context):
+    return elem in context.currencies
+
+
+def build_schema():
+    return {
+        MK.Type: types.NamedDict,
+        MK.Content: {
+            "exchange_rates": {
+                MK.Type: types.Dict,
+                MK.Content: {
+                    MK.Key: {MK.Type: types.String},
+                    MK.Value: {
+                        MK.Type: types.Number,
+                        MK.ElementValidators: (_positive_rate,),
+                    },
+                },
+            },
+            "transactions": {
+                MK.Type: types.List,
+                MK.Content: {
+                    MK.Item: {
+                        MK.Type: types.NamedDict,
+                        MK.Content: {
+                            "source": {
+                                MK.Type: types.String,
+                                MK.ContextValidators: (_is_currency,),
+                            },
+                            "target": {
+                                MK.Type: types.String,
+                                MK.ContextValidators: (_is_currency,),
+                            },
+                            "amount": {
+                                MK.Type: types.Number,
+                                MK.ElementValidators: (_positive_amount,),
+                            },
+                        },
+                    }
+                },
+            },
+        },
+    }
+
+
+def build_config():
+    return {
+        "exchange_rates": {
+            "NOK": 1,
+            "EUR": 9.67,
+            "USD": 8.68,
+            "FLC": 0.0024,
+            "Bitcoin": 0.000022,
+        },
+        "transactions": [
+            {"source": "NOK", "target": "USD", "amount": 1000},
+            {"source": "Bitcoin", "target": "EUR", "amount": 1},
+            {"source": "FLC", "target": "FLC", "amount": 0.001},
+        ],
+    }
+
+
+def extract_validation_context(configuration):
+    currencies = ()
+    if configuration.exchange_rates is not None:
+        currencies = tuple([cur_name for cur_name, _ in configuration.exchange_rates])
+
+    Context = collections.namedtuple("Context", ("currencies"))
+    return Context(currencies)

--- a/tests/test_context_element_validators.py
+++ b/tests/test_context_element_validators.py
@@ -1,0 +1,65 @@
+"""Copyright 2019 Equinor ASA and The Netherlands Organisation for
+Applied Scientific Research TNO.
+
+Licensed under the MIT license.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the conditions stated in the LICENSE file in the project root for
+details.
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+"""
+
+
+import unittest
+
+import configsuite
+
+from .data import transactions
+
+
+class TestContextValidators(unittest.TestCase):
+    def test_context_validator_valid(self):
+        raw_config = transactions.build_config()
+        config_suite = configsuite.ConfigSuite(
+            raw_config,
+            transactions.build_schema(),
+            extract_validation_context=transactions.extract_validation_context,
+        )
+        self.assertTrue(config_suite.valid)
+
+    def test_context_validator_unknown_currency(self):
+        raw_config = transactions.build_config()
+        raw_config["transactions"].append(
+            {"source": "NOK", "target": "Unknown currency", "amount": 1e30}
+        )
+        config_suite = configsuite.ConfigSuite(
+            raw_config,
+            transactions.build_schema(),
+            extract_validation_context=transactions.extract_validation_context,
+        )
+        self.assertFalse(config_suite.valid)
+        self.assertEqual(1, len(config_suite.errors))
+        err = config_suite.errors[0]
+        self.assertIsInstance(err, configsuite.InvalidValueError)
+        self.assertEqual(
+            ("transactions", len(raw_config["transactions"]) - 1, "target"),
+            err.key_path,
+        )
+
+    def test_context_validator_no_context_data_no_crash(self):
+        raw_config = transactions.build_config()
+        raw_config["exhange_rates"] = "Tulips is all you need!"
+        config_suite = configsuite.ConfigSuite(
+            raw_config,
+            transactions.build_schema(),
+            extract_validation_context=transactions.extract_validation_context,
+        )
+        self.assertFalse(config_suite.valid)
+        self.assertEqual(1, len(config_suite.errors))

--- a/tests/test_elem_validator_msg.py
+++ b/tests/test_elem_validator_msg.py
@@ -52,8 +52,42 @@ class TestElemValidatorMsg(unittest.TestCase):
         def identity(arg):
             return arg
 
-        res_msg_fmt = "{} is {} on input {}"
+        res_msg_fmt = "{} is {} on input '{}'"
         for x in (True, False):
             expected_msg = res_msg_fmt.format(msg, str(x).lower(), x)
             # pylint: disable=no-member
             self.assertEqual(expected_msg, identity(x).msg)
+
+    def test_multi_arg_msg(self):
+        msg = "The and function"
+
+        @configsuite.validator_msg(msg)
+        def _and(arg1, arg2):
+            return arg1 and arg2
+
+        expected_msg = "The and function is false on input 'True, False'"
+        # pylint: disable=no-member
+        self.assertEqual(expected_msg, _and(True, False).msg)
+
+    def test_result_msg_default_keyword(self):
+        msg = "The indentify function"
+
+        @configsuite.validator_msg(msg)
+        def identity(arg, return_none=False):
+            return None if return_none else arg
+
+        res_msg_fmt = "{} is {} on input '{}'"
+        for x in (True, False):
+            expected_msg = res_msg_fmt.format(msg, str(x).lower(), x)
+            # pylint: disable=no-member
+            self.assertEqual(expected_msg, identity(x).msg)
+
+    def test_keyword_arg(self):
+        msg = "The valid sum function"
+
+        @configsuite.validator_msg(msg)
+        def valid_sum(a, b, target_sum=42):
+            return a + b == target_sum
+
+        expected_msg = msg + " is true on input '8, 12, target_sum=20'"
+        self.assertEqual(expected_msg, valid_sum(8, 12, target_sum=20).msg)

--- a/tests/test_element_validators.py
+++ b/tests/test_element_validators.py
@@ -45,7 +45,7 @@ class TestElementValidators(unittest.TestCase):
         err = config_suite.errors[0]
         self.assertIsInstance(err, configsuite.InvalidValueError)
         self.assertEqual((0, "name"), err.key_path)
-        self.assertEqual("Name should not be empty is false on input ", err.msg)
+        self.assertEqual("Name should not be empty is false on input ''", err.msg)
 
     def test_element_validator_double_fail(self):
         raw_config = data.candy_bag.build_config()

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -25,6 +25,10 @@ from . import data
 
 
 class TestLayers(unittest.TestCase):
+    def assertEqualSnapshots(self, first, second):
+        self.assertEqual(first.heroes, second.heroes)
+        self.assertEqual(sorted(first.villains), sorted(second.villains))
+
     def test_layers_named_dict_disjoint_push(self):
         schema = data.hero.build_schema()
 
@@ -86,7 +90,9 @@ class TestLayers(unittest.TestCase):
         combined_config = configsuite.ConfigSuite(combined, schema)
         self.assertTrue(combined_config.valid)
 
-        self.assertEqual(combined_config.snapshot, hero_villains_config.snapshot)
+        self.assertEqualSnapshots(
+            combined_config.snapshot, hero_villains_config.snapshot
+        )
 
     def test_layers_named_dict_disjoint_init(self):
         schema = data.hero.build_schema()
@@ -174,7 +180,7 @@ class TestLayers(unittest.TestCase):
         combined_config = configsuite.ConfigSuite(combined, schema)
         self.assertTrue(combined_config.valid)
 
-        self.assertEqual(combined_config.snapshot, layered_config.snapshot)
+        self.assertEqualSnapshots(combined_config.snapshot, layered_config.snapshot)
 
     def test_invalid_layer(self):
         schema = data.hero.build_schema()

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -210,10 +210,7 @@ class TestLayers(unittest.TestCase):
         )
         self.assertTrue(layered_config.readable)
         self.assertFalse(layered_config.valid)
-        layer_errors = [
-            error for error in layered_config.errors if error.layer is not None
-        ]
-        self.assertTrue(len(layer_errors) > 0)
+        self.assertTrue(len(layered_config.errors) > 0)
 
         combined = {
             "heroes": [{"name": "Batman"}, {"name": "Batman", "strength": 10}],

--- a/tests/test_readable.py
+++ b/tests/test_readable.py
@@ -42,6 +42,7 @@ class TestReadable(unittest.TestCase):
         layered_config = configsuite.ConfigSuite(heroes, schema, layers=(villains,))
         self.assertFalse(layered_config.readable)
         self.assertFalse(layered_config.valid)
+        self.assertTrue(all([err.layer is not None for err in layered_config.errors]))
 
     def test_readable_not_valid(self):
         schema = data.hero.build_schema()

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -24,6 +24,7 @@ from configsuite import MetaKeys as MK
 from configsuite import types
 
 from . import data
+from .data import transactions
 
 
 class TestSchemaValidation(unittest.TestCase):
@@ -99,3 +100,19 @@ class TestSchemaValidation(unittest.TestCase):
         schema[MK.Content]["dubious"] = "content"
         with self.assertRaises(KeyError):
             configsuite.ConfigSuite(raw_config, schema)
+
+    def test_context_validator_for_container(self):
+        raw_config = transactions.build_config()
+        schema = transactions.build_schema()
+
+        @configsuite.validator_msg("Given a context I'll accept anything")
+        def _tautology(*_):
+            return True
+
+        schema[MK.ContextValidators] = (_tautology,)
+        with self.assertRaises(ValueError):
+            configsuite.ConfigSuite(
+                raw_config,
+                schema,
+                extract_validation_context=transactions.extract_validation_context,
+            )


### PR DESCRIPTION
Resolve #38

We should merge #44 before this one.

- _Stop sorting dict keys in snapshot_: If a config is `readable` we should be able to build a snapshot. However, sorting is not applicable for incomparable types in `Python 3`, hence this is not feasible. The sorting was added only for simpler equality testing, so no problem to remove it.

- _Fix multi argument bug for validator_msg_: When multiple arguments was passed to a function wrapped by the `validation_msg` decorator the code would fail. Fixed the bug and added tests.

- `Add support for context aware element validation`: Implements support for context aware validation. This is only allowed for `BasicTypes`, because then we can assume readability, and hence the function building the context can get the snapshot instead, which is much easier to work with although the types of the `BasicTypes` might be wrong.