### PR TITLE
Remove layer validation

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -210,10 +210,7 @@ class TestLayers(unittest.TestCase):
         )
         self.assertTrue(layered_config.readable)
         self.assertFalse(layered_config.valid)
-        layer_errors = [
-            error for error in layered_config.errors if error.layer is not None
-        ]
-        self.assertTrue(len(layer_errors) > 0)
+        self.assertTrue(len(layered_config.errors) > 0)
 
         combined = {
             "heroes": [{"name": "Batman"}, {"name": "Batman", "strength": 10}],

--- a/tests/test_readable.py
+++ b/tests/test_readable.py
@@ -42,6 +42,7 @@ class TestReadable(unittest.TestCase):
         layered_config = configsuite.ConfigSuite(heroes, schema, layers=(villains,))
         self.assertFalse(layered_config.readable)
         self.assertFalse(layered_config.valid)
+        self.assertTrue(all([err.layer is not None for err in layered_config.errors]))
 
     def test_readable_not_valid(self):
         schema = data.hero.build_schema()


### PR DESCRIPTION
It was a mistake to implement enforced layer validation. The motivation was to ensure that invalid values in lower level configuration layers is not masked by upper levels. Which is a good philosophy in some cases, but:

- the same functionality is easily implemented by the consumer by building your suite layer for layer, looking for `InvalidValueError`'s for each layer you add.
- When `context`'s are introduced (i.e. a global state can affect the validation), it is context dependent together with consumer philosophy dependent whether one could and/or should be able to have intermediate layers that are invalid without the following layers.