### PR TITLE
Allow context validators for collections

### DIFF
--- a/configsuite/config.py
+++ b/configsuite/config.py
@@ -324,7 +324,7 @@ class ConfigSuite(object):
             return not isinstance(schema[MK.Type], configsuite.types.Collection)
 
         container_validator = configsuite.Validator(
-            self._schema, stop_condition=_not_container
+            self._schema, stop_condition=_not_container, apply_validators=False
         )
         container_errors = []
         for idx, layer in enumerate(layers):

--- a/configsuite/schema.py
+++ b/configsuite/schema.py
@@ -25,16 +25,8 @@ from configsuite import MetaKeys as MK
 from configsuite import types
 
 
-@configsuite.validator_msg("Collections cannot be context validated")
-def _context_basic_only(elem):
-    return not (
-        isinstance(elem[MK.Type], types.Collection) and MK.ContextValidators in elem
-    )
-
-
 _META_SCHEMA = {
     MK.Type: types.NamedDict,
-    MK.ElementValidators: (_context_basic_only,),
     MK.Content: {
         MK.Type: {MK.Type: types.Type},
         MK.Required: {MK.Type: types.Bool, MK.Required: False},

--- a/configsuite/validator.py
+++ b/configsuite/validator.py
@@ -26,12 +26,15 @@ ValidationResult = collections.namedtuple("ValidationResult", ("valid", "errors"
 
 
 class Validator(object):
-    def __init__(self, schema, stop_condition=(lambda schema: False)):
+    def __init__(
+        self, schema, stop_condition=(lambda schema: False), apply_validators=True
+    ):
         self._schema = schema
         self._errors = None
         self._key_stack = None
         self._context = None
         self._stop_condition = stop_condition
+        self._apply_validators = apply_validators
 
     def validate(self, config, context=None):
         self._errors = []
@@ -61,10 +64,10 @@ class Validator(object):
             msg = "Unknown type {} while validating"
             raise TypeError(msg.format(data_type))
 
-        if valid:
+        if self._apply_validators and valid:
             valid &= self._element_validation(config, schema)
 
-        if valid:
+        if self._apply_validators and valid:
             valid &= self._context_validation(config, schema)
 
         return bool(valid)

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -26,3 +26,4 @@ from . import hero
 from . import transactions
 from . import templating
 from . import numbers
+from . import special_numbers

--- a/tests/data/special_numbers.py
+++ b/tests/data/special_numbers.py
@@ -1,0 +1,93 @@
+"""Copyright 2019 Equinor ASA and The Netherlands Organisation for
+Applied Scientific Research TNO.
+
+Licensed under the MIT license.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the conditions stated in the LICENSE file in the project root for
+details.
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+"""
+
+
+import configsuite
+from configsuite import MetaKeys as MK
+from configsuite import types
+
+
+@configsuite.validator_msg("Is preference consistence with favourite")
+def _preference_favourite_consistency(person, context):
+    if person["prefer_normal"]:
+        valid_nums = set(context.normal_numbers)
+    else:
+        valid_nums = set(context.special_numbers)
+
+    favourite_nums = set(person["favourite_numbers"])
+    return favourite_nums.issubset(valid_nums)
+
+
+def extract_context(configuration):
+    return configuration
+
+
+_PERSON_SCHEMA = {
+    MK.Type: types.NamedDict,
+    MK.ContextValidators: (_preference_favourite_consistency,),
+    MK.Content: {
+        "prefer_normal": {MK.Type: types.Bool},
+        "favourite_numbers": {
+            MK.Type: types.List,
+            MK.Content: {MK.Item: {MK.Type: types.Integer}},
+        },
+    },
+}
+
+
+def build_schema():
+    return {
+        MK.Type: types.NamedDict,
+        MK.Content: {
+            "special_numbers": {
+                MK.Type: types.List,
+                MK.Content: {MK.Item: {MK.Type: types.Integer}},
+            },
+            "normal_numbers": {
+                MK.Type: types.List,
+                MK.Content: {MK.Item: {MK.Type: types.Integer}},
+            },
+            "questionnaire": {
+                MK.Type: types.List,
+                MK.Content: {MK.Item: _PERSON_SCHEMA},
+            },
+            "mathematicians": {
+                MK.Type: types.Dict,
+                MK.Content: {MK.Key: {MK.Type: types.String}, MK.Value: _PERSON_SCHEMA},
+            },
+            "others": {MK.Type: types.NamedDict, MK.Content: {"self": _PERSON_SCHEMA}},
+        },
+    }
+
+
+def build_config():
+    return {
+        "special_numbers": [1, 2, 6, 18],
+        "normal_numbers": [3, 4, 5, 7, 15, 31],
+        "questionnaire": [
+            {"prefer_normal": True, "favourite_numbers": [3, 15]},
+            {"prefer_normal": False, "favourite_numbers": [1, 6, 18]},
+        ],
+        "mathematicians": {
+            "Frank P. Ramsey": {
+                "prefer_normal": False,
+                "favourite_numbers": [1, 2, 6, 18],
+            }
+        },
+        "others": {"self": {"prefer_normal": True, "favourite_numbers": [4, 7, 31]}},
+    }

--- a/tests/test_context_element_validators.py
+++ b/tests/test_context_element_validators.py
@@ -22,6 +22,7 @@ import unittest
 import configsuite
 
 from .data import transactions
+from .data import special_numbers
 
 
 class TestContextValidators(unittest.TestCase):
@@ -94,3 +95,25 @@ class TestContextValidators(unittest.TestCase):
         layered_suite = suite.push(top_layer)
 
         self.assertTrue(layered_suite.valid)
+
+    def test_context_validator_container(self):
+        suite = configsuite.ConfigSuite(
+            special_numbers.build_config(),
+            special_numbers.build_schema(),
+            extract_validation_context=special_numbers.extract_context,
+        )
+
+        self.assertTrue(suite.valid, suite.errors)
+
+    def test_context_validator_faulty_container(self):
+        config = special_numbers.build_config()
+        config["others"]["self"] = "I'm a snow flake"
+
+        suite = configsuite.ConfigSuite(
+            config,
+            special_numbers.build_schema(),
+            extract_validation_context=special_numbers.extract_context,
+        )
+
+        self.assertFalse(suite.readable)
+        self.assertFalse(suite.valid)

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -24,7 +24,6 @@ from configsuite import MetaKeys as MK
 from configsuite import types
 
 from . import data
-from .data import transactions
 
 
 class TestSchemaValidation(unittest.TestCase):
@@ -100,19 +99,3 @@ class TestSchemaValidation(unittest.TestCase):
         schema[MK.Content]["dubious"] = "content"
         with self.assertRaises(KeyError):
             configsuite.ConfigSuite(raw_config, schema)
-
-    def test_context_validator_for_container(self):
-        raw_config = transactions.build_config()
-        schema = transactions.build_schema()
-
-        @configsuite.validator_msg("Given a context I'll accept anything")
-        def _tautology(*_):
-            return True
-
-        schema[MK.ContextValidators] = (_tautology,)
-        with self.assertRaises(ValueError):
-            configsuite.ConfigSuite(
-                raw_config,
-                schema,
-                extract_validation_context=transactions.extract_validation_context,
-            )


### PR DESCRIPTION
When first implemented, context validators was not allowed for containers. However, it is in some cases convenient to be able to context validate containers. In addition, since one can context transform them, the current disallowance seems a bit arbitrary.

The original motivation was so that the context extractor could get a snapshot instead of a raw configuration. Making the extraction much easier and predictable. However, the validators are not needed to deem readability. Hence, we can:

- validate readability without validators (in particular without the context validators)
- apply transformations (notice that at this point we already did extract contexts for the transformations),
- validate full configuration, including context validators.