### PR TITLE
Add Circle CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Config Suite #
 
 [![Build Status](https://travis-ci.org/equinor/configsuite.svg?branch=master)](https://travis-ci.org/equinor/configsuite)
+[![CircleCI](https://circleci.com/gh/equinor/configsuite.svg?style=svg)](https://circleci.com/gh/equinor/configsuite)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/042d23ea22084a1c8c7396edc6d1709f)](https://www.codacy.com/app/markusdregi/configsuite?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=equinor/configsuite&amp;utm_campaign=Badge_Grade)


### PR DESCRIPTION
Following up #81 by adding the Circle CI badge to the README