### PR TITLE
[WIP] Add YAML preprocessor class

### DIFF
--- a/configsuite/yaml_processor.py
+++ b/configsuite/yaml_processor.py
@@ -1,0 +1,105 @@
+"""Copyright 2019 Equinor ASA and The Netherlands Organisation for
+Applied Scientific Research TNO.
+
+Licensed under the MIT license.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the conditions stated in the LICENSE file in the project root for
+details.
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+"""
+
+from yaml import SafeLoader, ScalarNode, SequenceNode, MappingNode
+
+
+class DuplicateKeyError(Exception):
+    def __init__(self, key_path, mark, first_mark):
+        self._key_path = key_path
+        self._mark = mark
+        self._first_mark = first_mark
+
+    def __str__(self):
+        return "Duplicate key '{}' found:\n {}\nFirst occurrence:\n {}".format(
+            self.key_path[-1], str(self.mark), self.first_mark
+        )
+
+    @property
+    def key_path(self):
+        return self._key_path
+
+    @property
+    def mark(self):
+        return self._mark
+
+    @property
+    def first_mark(self):
+        return self._first_mark
+
+    def __eq__(self, other):
+        return self._mark == other._mark
+
+    def __neq__(self, other):
+        return not (self == other)
+
+    def __hash__(self):
+        return hash(self._mark)
+
+
+class YamlProcessor(object):
+    def __init__(self, layer):
+        self._documents = []
+        self._key_path = []
+        self._keys = {}
+
+        self._load_layer(layer)
+
+    def get_documents(self):
+        return self._documents
+
+    def get_mark(self, key_path):
+        if key_path in self._keys:
+            return self._keys[key_path]
+
+    def _load_layer(self, layer):
+        self._loader = SafeLoader(layer)
+        while self._loader.check_node():
+            node = self._loader.get_node()
+            self._process_node(node)
+            self._documents.append(self._loader.construct_document(node))
+
+    def _process_node(self, node):
+        if isinstance(node, ScalarNode):
+            pass
+
+        elif isinstance(node, SequenceNode):
+            for idx, val in enumerate(node.value):
+                self._key_path.append(idx)
+                self._keys[tuple(self._key_path)] = val.start_mark
+
+                self._process_node(val)
+                self._key_path.pop()
+
+        elif isinstance(node, MappingNode):
+            keys = {}
+            for key, val in node.value:
+                assert isinstance(key, ScalarNode)
+                obj = self._loader.construct_object(key)
+
+                self._key_path.append(obj)
+
+                if obj in keys:
+                    raise DuplicateKeyError(self._key_path, key.start_mark, keys[obj])
+                else:
+                    keys[obj] = key.start_mark
+
+                self._keys[tuple(self._key_path)] = val.start_mark
+
+                self._process_node(val)
+                self._key_path.pop()

--- a/tests/test_yaml_processor.py
+++ b/tests/test_yaml_processor.py
@@ -1,0 +1,70 @@
+"""Copyright 2019 Equinor ASA and The Netherlands Organisation for
+Applied Scientific Research TNO.
+
+Licensed under the MIT license.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the conditions stated in the LICENSE file in the project root for
+details.
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+"""
+
+import unittest
+from configsuite import ConfigSuite, types, MetaKeys as MK
+from configsuite.yaml_processor import YamlProcessor, DuplicateKeyError
+
+_yaml = """
+---
+- first: document
+  second: still the same document
+  hash:
+    foo: 1
+    bar: 2
+    zip: zoop
+"""
+
+
+class TestYamlProcessor(unittest.TestCase):
+    def test_init(self):
+        YamlProcessor(_yaml)
+
+    def test_duplicate(self):
+        conf = "a: 1\nb: 2\na: 3\n"
+
+        with self.assertRaises(DuplicateKeyError):
+            YamlProcessor(conf)
+
+    def test_key_lookup(self):
+        schema = {
+            MK.Type: types.List,
+            MK.Content: {
+                MK.Item: {
+                    MK.Type: types.NamedDict,
+                    MK.Content: {
+                        "first": {MK.Type: types.String},
+                        "second": {MK.Type: types.String},
+                        "hash": {MK.Type: types.String},  # Correctly invalid schema
+                    },
+                }
+            },
+        }
+
+        proc = YamlProcessor(_yaml)
+        suite = ConfigSuite(proc.get_documents()[0], schema)
+
+        self.assertFalse(suite.valid)
+        self.assertEqual(len(suite.errors), 1)
+
+        error, = suite.errors
+        mark = proc.get_mark(error.key_path)
+
+        # FIXME: This shows that the error occurs on `foo: 1`, instead of the previous line where it'd be correct.
+        self.assertEqual(mark.line, 5)
+        self.assertEqual(mark.column, 4)


### PR DESCRIPTION
Currently it's able to detect duplicate entries in YAML blocks and stores the position of every YAML key in the document, which we can then retrieve if a ConfigSuite validation error occurs.