### PR TITLE
Fix code in docs with respect to allowing None

### DIFF
--- a/docs/source/user_guide/getting_started.rst
+++ b/docs/source/user_guide/getting_started.rst
@@ -841,6 +841,7 @@ And now, we can insert this into the schema as follows:
                     "credit": {
                         MK.Type: types.Number,
                         MK.Required: False,
+                        MK.AllowNone: True,
                         MK.Transformation: _to_float,
                     },
                     "insured": {MK.Type: types.Bool},


### PR DESCRIPTION
The introduction of `allow_none` in #89 broke the new documentation tests from #96 when they were merged independently.