### PR TITLE
Add allow_none vs default vs required tests

### DIFF
--- a/configsuite/schema.py
+++ b/configsuite/schema.py
@@ -44,12 +44,14 @@ def _check_allownone_type(schema_level):
     "Non required types must allow None or have non-None default"
 )
 def _check_allownone_required(schema_level):
-    if isinstance(schema_level[MK.Type], types.BasicType):
-        allow_none = schema_level.get(MK.AllowNone, False)
-        has_non_none_default = schema_level.get(MK.Default) is not None
-        if not allow_none and not has_non_none_default:
-            return schema_level.get(MK.Required, True)
-    return True
+    is_required = schema_level.get(MK.Required, True)
+    is_basic_type = isinstance(schema_level[MK.Type], types.BasicType)
+    if is_required or not is_basic_type:
+        return True
+
+    allow_none = schema_level.get(MK.AllowNone, False)
+    has_non_none_default = schema_level.get(MK.Default) is not None
+    return allow_none or has_non_none_default
 
 
 @configsuite.validator_msg("Default can only be used for BasicType")

--- a/tests/test_allow_none.py
+++ b/tests/test_allow_none.py
@@ -61,19 +61,6 @@ class TestNotAllowNoneContainers(unittest.TestCase):
             "AllowNone can only be used for BasicType", str(error_context.exception)
         )
 
-    def test_not_required_implies_must_allow_none(self):
-        schema = computers.build_schema()
-        config = computers.build_config()
-
-        schema[MK.Content]["OS"][MK.Required] = False
-        schema[MK.Content]["OS"][MK.AllowNone] = False
-
-        with self.assertRaises(ValueError) as error_context:
-            configsuite.ConfigSuite(config, schema)
-        self.assertIn(
-            "Non required types must allow None", str(error_context.exception)
-        )
-
 
 class TestAllowNoneBasicType(unittest.TestCase):
     def test_basictype_explicit_none(self):

--- a/tests/test_allow_none_vs_default.py
+++ b/tests/test_allow_none_vs_default.py
@@ -1,0 +1,191 @@
+"""Copyright 2019 Equinor ASA and The Netherlands Organisation for
+Applied Scientific Research TNO.
+
+Licensed under the MIT license.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the conditions stated in the LICENSE file in the project root for
+details.
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+"""
+
+
+import unittest
+
+
+import configsuite
+from configsuite import MetaKeys as MK
+from configsuite import types
+
+
+class TestNotAllowNoneVsDefault(unittest.TestCase):
+    def test_allow_none_default_not_required(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {
+                "my_value": {
+                    MK.Type: types.Integer,
+                    MK.AllowNone: True,
+                    MK.Required: False,
+                    MK.Default: 0,
+                },
+            },
+        }
+
+        for value in (-1, 4, 1000, None):
+            suite = configsuite.ConfigSuite({"my_value": value}, schema)
+            self.assertTrue(suite.valid)
+            self.assertEqual(value, suite.snapshot.my_value)
+
+        suite = configsuite.ConfigSuite({}, schema)
+        self.assertTrue(suite.valid)
+        self.assertEqual(0, suite.snapshot.my_value)
+
+    def test_allow_none_no_default_not_required(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {
+                "my_value": {
+                    MK.Type: types.Integer,
+                    MK.AllowNone: True,
+                    MK.Required: False,
+                },
+            },
+        }
+
+        for value in (-1, 4, 1000, None):
+            suite = configsuite.ConfigSuite({"my_value": value}, schema)
+            self.assertTrue(suite.valid)
+            self.assertEqual(value, suite.snapshot.my_value)
+
+        suite = configsuite.ConfigSuite({}, schema)
+        self.assertTrue(suite.valid)
+        self.assertEqual(None, suite.snapshot.my_value)
+
+    def test_disallow_none_default_not_required(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {
+                "my_value": {
+                    MK.Type: types.Integer,
+                    MK.AllowNone: False,
+                    MK.Default: 0,
+                    MK.Required: False,
+                },
+            },
+        }
+
+        for value in (-1, 4, 1000):
+            suite = configsuite.ConfigSuite({"my_value": value}, schema)
+            self.assertTrue(suite.valid, suite.errors)
+            self.assertEqual(value, suite.snapshot.my_value)
+
+            suite = configsuite.ConfigSuite({}, schema)
+            self.assertTrue(suite.valid)
+            self.assertEqual(0, suite.snapshot.my_value)
+
+        suite = configsuite.ConfigSuite({"my_value": None}, schema)
+        self.assertFalse(suite.valid)
+        self.assertEqual(None, suite.snapshot.my_value)
+
+    def test_disallow_none_no_default_not_required(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {
+                "my_value": {
+                    MK.Type: types.Integer,
+                    MK.AllowNone: False,
+                    MK.Required: False,
+                },
+            },
+        }
+
+        with self.assertRaises(ValueError) as error_context:
+            configsuite.ConfigSuite({}, schema)
+        self.assertIn(
+            "Non required types must allow None", str(error_context.exception)
+        )
+
+    def test_allow_none_default_required(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {
+                "my_value": {
+                    MK.Type: types.Integer,
+                    MK.AllowNone: True,
+                    MK.Default: 0,
+                    MK.Required: True,
+                },
+            },
+        }
+
+        with self.assertRaises(ValueError) as error_context:
+            configsuite.ConfigSuite({}, schema)
+        self.assertIn("Required can not have Default", str(error_context.exception))
+
+    def test_allow_none_no_default_required(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {
+                "my_value": {
+                    MK.Type: types.Integer,
+                    MK.AllowNone: True,
+                    MK.Required: True,
+                },
+            },
+        }
+
+        for value in (-1, 4, 1000, None):
+            suite = configsuite.ConfigSuite({"my_value": value}, schema)
+            self.assertTrue(suite.valid)
+            self.assertEqual(value, suite.snapshot.my_value)
+
+        suite = configsuite.ConfigSuite({}, schema)
+        self.assertFalse(suite.valid)
+        self.assertEqual(None, suite.snapshot.my_value)
+
+    def test_disallow_none_default_required(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {
+                "my_value": {
+                    MK.Type: types.Integer,
+                    MK.AllowNone: False,
+                    MK.Default: 0,
+                    MK.Required: True,
+                },
+            },
+        }
+
+        with self.assertRaises(ValueError) as error_context:
+            configsuite.ConfigSuite({}, schema)
+        self.assertIn("Required can not have Default", str(error_context.exception))
+
+    def test_disallow_none_no_default_required(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {
+                "my_value": {
+                    MK.Type: types.Integer,
+                    MK.AllowNone: False,
+                    MK.Required: True,
+                },
+            },
+        }
+
+        for value in (-1, 4, 1000):
+            suite = configsuite.ConfigSuite({"my_value": value}, schema)
+            self.assertTrue(suite.valid)
+            self.assertEqual(value, suite.snapshot.my_value)
+
+        for config in ({}, {"my_value": None}):
+            suite = configsuite.ConfigSuite(config, schema)
+            self.assertFalse(suite.valid)
+            self.assertEqual(None, suite.snapshot.my_value)

--- a/tests/test_default_values.py
+++ b/tests/test_default_values.py
@@ -146,17 +146,6 @@ class TestDefaultValues(unittest.TestCase):
             )
             self.assertTrue(err.msg.startswith("Is x a valid date"))
 
-    def test_default_and_required_not_allowed(self):
-        raw_config = car.build_config()
-        car_schema = car.build_schema()
-        car_schema[MK.Content]["tire"][MK.Content]["dimension"][MK.Required] = True
-
-        with self.assertRaises(ValueError) as error_context:
-            configsuite.ConfigSuite(raw_config, car_schema)
-        self.assertTrue(
-            str(error_context.exception).startswith("Default can not be Required")
-        )
-
     def test_not_allow_default_for_list(self):
         raw_config = car.build_all_default_config()
 


### PR DESCRIPTION
Implement tests (and the necessary code) to get all eight combinations of allowing None, giving a default value and being required to behave as expected.

| Allow None | Default value | Required | Valid |
|-|-|-|-|
| T | T | T | F |
| T | T | F | T |
| T | F | T | T |
| T | F | F | T |
| F | T | T | F |
| F | T | F | T |
| F | F | T | T |
| F | F | F | F |