### PR TITLE
Make required deducible

### DIFF
--- a/configsuite/schema.py
+++ b/configsuite/schema.py
@@ -40,6 +40,13 @@ def _check_allownone_type(schema_level):
     return True
 
 
+@configsuite.validator_msg("Required can only be used for BasicType")
+def _check_required_type(schema_level):
+    if MK.Required in schema_level:
+        return isinstance(schema_level[MK.Type], types.BasicType)
+    return True
+
+
 @configsuite.validator_msg(
     "A type is not required only if it allows None or have a non-None default"
 )
@@ -72,8 +79,9 @@ _META_SCHEMA = {
     MK.Type: types.NamedDict,
     MK.ElementValidators: (
         _check_allownone_type,
-        _check_allownone_required,
+        _check_required_type,
         _check_default_type,
+        _check_allownone_required,
         _check_required_not_default,
     ),
     MK.Content: {

--- a/configsuite/schema.py
+++ b/configsuite/schema.py
@@ -41,17 +41,17 @@ def _check_allownone_type(schema_level):
 
 
 @configsuite.validator_msg(
-    "Non required types must allow None or have non-None default"
+    "A type is not required only if it allows None or have a non-None default"
 )
 def _check_allownone_required(schema_level):
-    is_required = schema_level.get(MK.Required, True)
-    is_basic_type = isinstance(schema_level[MK.Type], types.BasicType)
-    if is_required or not is_basic_type:
+    if not isinstance(schema_level[MK.Type], types.BasicType):
         return True
 
+    is_required = schema_level.get(MK.Required, True)
     allow_none = schema_level.get(MK.AllowNone, False)
     has_non_none_default = schema_level.get(MK.Default) is not None
-    return allow_none or has_non_none_default
+
+    return is_required != allow_none or has_non_none_default
 
 
 @configsuite.validator_msg("Default can only be used for BasicType")

--- a/docs/source/user_guide/getting_started.rst
+++ b/docs/source/user_guide/getting_started.rst
@@ -546,6 +546,7 @@ in order for a configuration with ``None`` to pass.
                     "credit": {
                         MK.Type: types.Number,
                         MK.AllowNone: True,
+                        MK.Required: False,
                     },
                     "insured": {MK.Type: types.Bool},
                 },

--- a/tests/data/candidate.py
+++ b/tests/data/candidate.py
@@ -29,7 +29,6 @@ def build_schema():
             "weight": {MK.Type: types.Number, MK.Required: False, MK.AllowNone: True},
             "current_job": {
                 MK.Type: types.NamedDict,
-                MK.Required: False,
                 MK.Content: {
                     "company_name": {MK.Type: types.String},
                     "position": {

--- a/tests/data/car.py
+++ b/tests/data/car.py
@@ -38,7 +38,6 @@ def build_schema():
             },
             "tire": {
                 MK.Type: types.NamedDict,
-                MK.Required: False,
                 MK.Content: {
                     "dimension": {
                         MK.Type: types.Number,
@@ -56,7 +55,6 @@ def build_schema():
             },
             "owner": {
                 MK.Type: types.Dict,
-                MK.Required: False,
                 MK.Content: {
                     MK.Key: {MK.Type: types.String},
                     MK.Value: {
@@ -75,7 +73,6 @@ def build_schema():
             },
             "incidents": {
                 MK.Type: types.List,
-                MK.Required: False,
                 MK.Content: {
                     MK.Item: {
                         MK.Type: types.NamedDict,
@@ -141,7 +138,11 @@ def extract_production_date(snapshot):
 
 
 def build_all_default_config():
-    return {"production_date": datetime.datetime(2000, 1, 1)}
+    return {
+        "production_date": datetime.datetime(2000, 1, 1),
+        "owner": {},
+        "incidents": [],
+    }
 
 
 def build_config():

--- a/tests/data/templating.py
+++ b/tests/data/templating.py
@@ -114,7 +114,6 @@ def build_schema_with_definitions():
         MK.Content: {
             "definitions": {
                 MK.Type: types.Dict,
-                MK.Required: False,
                 MK.Content: {
                     MK.Key: {MK.Type: types.String},
                     MK.Value: {MK.Type: types.String},

--- a/tests/test_allow_none.py
+++ b/tests/test_allow_none.py
@@ -68,6 +68,7 @@ class TestAllowNoneBasicType(unittest.TestCase):
         config = computers.build_config()
 
         schema[MK.Content]["OS"][MK.AllowNone] = True
+        schema[MK.Content]["OS"][MK.Required] = False
 
         config["OS"] = None
         config_suite = configsuite.ConfigSuite(config, schema)

--- a/tests/test_allow_none_vs_default.py
+++ b/tests/test_allow_none_vs_default.py
@@ -109,9 +109,7 @@ class TestNotAllowNoneVsDefault(unittest.TestCase):
 
         with self.assertRaises(ValueError) as error_context:
             configsuite.ConfigSuite({}, schema)
-        self.assertIn(
-            "Non required types must allow None", str(error_context.exception)
-        )
+        self.assertIn("A type is not required only if", str(error_context.exception))
 
     def test_allow_none_default_required(self):
         schema = {
@@ -142,14 +140,9 @@ class TestNotAllowNoneVsDefault(unittest.TestCase):
             },
         }
 
-        for value in (-1, 4, 1000, None):
-            suite = configsuite.ConfigSuite({"my_value": value}, schema)
-            self.assertTrue(suite.valid)
-            self.assertEqual(value, suite.snapshot.my_value)
-
-        suite = configsuite.ConfigSuite({}, schema)
-        self.assertFalse(suite.valid)
-        self.assertEqual(None, suite.snapshot.my_value)
+        with self.assertRaises(ValueError) as error_context:
+            configsuite.ConfigSuite({}, schema)
+        self.assertIn("A type is not required only if", str(error_context.exception))
 
     def test_disallow_none_default_required(self):
         schema = {

--- a/tests/test_default_values.py
+++ b/tests/test_default_values.py
@@ -203,7 +203,6 @@ class TestDefaultValues(unittest.TestCase):
         car_schema = car.build_schema()
         schema_value_content = {
             MK.Type: types.Dict,
-            MK.Required: False,
             MK.Content: {
                 MK.Key: {
                     MK.Type: types.String,
@@ -226,7 +225,6 @@ class TestDefaultValues(unittest.TestCase):
         car_schema = car.build_schema()
         schema_value_content = {
             MK.Type: types.Dict,
-            MK.Required: False,
             MK.Content: {
                 MK.Key: {MK.Type: types.String},
                 MK.Value: {

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -68,7 +68,7 @@ class TestKeys(unittest.TestCase):
         self.assertTrue(config_suite.valid)
         self.assertEqual(None, config_suite.snapshot.weight)
 
-    def test_required_if_parent(self):
+    def test_required_child(self):
         raw_config = data.candidate.build_config()
         raw_config["current_job"].pop("company_name")
         config_suite = configsuite.ConfigSuite(
@@ -81,7 +81,7 @@ class TestKeys(unittest.TestCase):
         self.assertIsInstance(err, configsuite.MissingKeyError)
         self.assertEqual(("current_job",), err.key_path)
 
-    def test_optional_child_of_optional(self):
+    def test_optional_child(self):
         raw_config = data.candidate.build_config()
         raw_config["current_job"].pop("position")
         config_suite = configsuite.ConfigSuite(


### PR DESCRIPTION
In #112 tests and code where added to validate all combinations of `allow none`, `required` and `default`. However, a design flaw was made! It can be seen by inspecting the combination table in the PR text:

| Allow None | Default value | Required | Valid |
|-|-|-|-|
| ... | ... | ... | ... |
| T | F | T | T |
| T | F | F | T |
| ... | ... | ... | ... |

Notice that if we `allow none` and do not provide a `default value` we allow the schema to specify the element both as `required` and as not `required`. This was lenient, but a mistake! In particular we allow the element to be none, it is not required to pass a value. Hence if required is set as true this should yield an error. This is the exact change that the first commit enforces.

The second commit removes the possibility of setting a dictionary as required (this was never allowed for a list). This is indeed better design as a container's requiredness should be dictated by their entries alone.

The main benefit from this is that after this change `required` is indeed deducible from `allow none` and `default` and can hence start its journey towards deprecation.