### PR TITLE
Validator deduce required

### DIFF
--- a/configsuite/validator.py
+++ b/configsuite/validator.py
@@ -109,11 +109,16 @@ class Validator(object):
         return len(unknown_keys) == 0
 
     def _identify_missing_dict_keys(self, config, content_schema):
-        optional_keys = [
-            key
-            for key in content_schema
-            if not content_schema[key].get(MK.Required, True)
-        ]
+        optional_keys = []
+        for key in content_schema:
+            deduced_required = not (
+                content_schema[key].get(MK.AllowNone, False)
+                or content_schema[key].get(MK.Default, None) is not None
+            )
+
+            if not deduced_required:
+                optional_keys.append(key)
+
         missing_keys = (
             set(content_schema.keys()) - set(config.keys()) - set(optional_keys)
         )


### PR DESCRIPTION
This PR build on #123 and only the last two commits is original content.

The first makes the validator deduce `required` from `allow_none` and `default`, with assertions demonstrating that they are indeed the same for all tests. The later removes the assert to make the validator completely independent of the `required`-property.

The two commits should be squashed before merging!