### PR TITLE
Deduce required option

### DIFF
--- a/configsuite/config.py
+++ b/configsuite/config.py
@@ -52,6 +52,13 @@ class ConfigSuite(object):
         Callable that extracts the context used for transformations. The
         callable is given a snapshot of the configuration as argument. Defaults
         to the constant function always returning `None`.
+    deduce_required: bool, optional
+        Boolean that enables future behaviour of deducing whether a schema
+        entry is `required` by inspecting `allow_none` and `default`. In
+        particular, using `required` in schemas as well as not setting
+        `deduce_required=True` is deprecated.
+
+
 
     Raises
     ------
@@ -68,8 +75,9 @@ class ConfigSuite(object):
         layers=(),
         extract_validation_context=lambda snapshot: None,
         extract_transformation_context=lambda snapshot: None,
+        deduce_required=False,
     ):
-        assert_valid_schema(schema)
+        assert_valid_schema(schema, deduce_required=deduce_required)
         self._layers = tuple(
             [copy.deepcopy(layer) for layer in tuple(layers) + (raw_config,)]
         )

--- a/tests/test_deprecation_warning.py
+++ b/tests/test_deprecation_warning.py
@@ -1,0 +1,81 @@
+"""Copyright 2020 Equinor ASA and The Netherlands Organisation for
+Applied Scientific Research TNO.
+
+Licensed under the MIT license.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the conditions stated in the LICENSE file in the project root for
+details.
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+"""
+
+
+import unittest
+import warnings
+
+import configsuite
+from configsuite import MetaKeys as MK
+from configsuite import types
+
+
+class TestRequiredDeprecated(unittest.TestCase):
+    def test_explicit_required_is_deprecated(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {"some_key": {MK.Type: types.String, MK.Required: True}},
+        }
+        with warnings.catch_warnings(record=True) as wc:
+            configsuite.ConfigSuite({}, schema)
+            self.assertEqual(1, len(wc))
+            self.assertEqual(__file__, wc[0].filename)
+            self.assertIn(
+                "Use `ConfigSuite(..., deduce_required=True)`", str(wc[0].message)
+            )
+
+    def test_specifying_required_is_deprecated_when_deducing(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {"some_key": {MK.Type: types.String, MK.Required: True}},
+        }
+        with warnings.catch_warnings(record=True) as wc:
+            configsuite.ConfigSuite({}, schema, deduce_required=True)
+            self.assertEqual(1, len(wc))
+            self.assertEqual(__file__, wc[0].filename)
+            self.assertIn("Please remove them from your schema", str(wc[0].message))
+
+    def test_no_deprecation_warning_when_deducing(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {"some_key": {MK.Type: types.String}},
+        }
+        with warnings.catch_warnings(record=True) as wc:
+            suite = configsuite.ConfigSuite({}, schema, deduce_required=True)
+            self.assertFalse(suite.valid)
+            self.assertEqual(0, len(wc))
+
+    def test_no_error_when_deducing_from_allow_none(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {"some_key": {MK.Type: types.String, MK.AllowNone: True}},
+        }
+        with warnings.catch_warnings(record=True) as wc:
+            suite = configsuite.ConfigSuite({}, schema, deduce_required=True)
+            self.assertTrue(suite.valid)
+            self.assertEqual(0, len(wc))
+
+    def test_no_error_when_deducing_from_default(self):
+        schema = {
+            MK.Type: types.NamedDict,
+            MK.Content: {"some_key": {MK.Type: types.String, MK.Default: "A string"}},
+        }
+        with warnings.catch_warnings(record=True) as wc:
+            suite = configsuite.ConfigSuite({}, schema, deduce_required=True)
+            self.assertTrue(suite.valid)
+            self.assertEqual(0, len(wc))


### PR DESCRIPTION
This PR builds on #123, #124, #125 and #126. Only the last commit is original for this PR.

The aim of this PR is best illustrated by the test `test_deprecation_warning.py`. The idea is that the user should start by setting `allow_none` and `default` as necessary (I'll write a description in the release notes). Then, they will get a deprecation warning on not activating `deduced_required`. Afterwards, they will get deprecation warnings if their schema's contain `Required` and they can now safely be removed.

The plan is then that in `0.7` we deprecate setting `deduced_required` and remove the meta key `Required`. In `0.8` the `deduced_required` option will be gone.

I think this is as smooth as possible a transfer into the current direction of development of configsuite.

Resolves: #122

**Note**
The PR also contains the commit from #128 