### PR TITLE
0.6 docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,7 @@ A guide through the universe of *Config Suite*.
     user_guide/introduction
     user_guide/getting_started
     user_guide/advanced
+    user_guide/deprecated_behaviour
 
 
 Additional examples

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,17 @@ Additional examples
 
 For additional examples we refer the reader to the `test data <https://github.com/equinor/configsuite/tree/master/tests/data>`_.
 
+Release Notes
+-------------
+
+An overview of the *Config Suite* releases.
+
+.. toctree::
+    :maxdepth: 2
+
+    release_notes
+
+
 The API Documentation
 ---------------------
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,0 +1,138 @@
+Release Notes
+=============
+
+.. Release note sections:
+   New features
+   Improvements
+   Bugfixes
+   Deprecations
+   Dependencies
+   Miscellaneous
+
+
+dev
+---
+
+**New features**
+ - Specify elements to be allowed to take None as value
+ - Specify default values for elements in the schema
+ - Generate documentation from schema a Sphinx plugin
+
+**Improvements**
+ - Python 3.8 support
+
+**Deprecations**
+ - Specifying elements as Required in the schema
+ - Python 3.4 support
+
+**Miscellaneous**
+ - Use `flake8` as part of the CI pipeline
+ - Have the CI pipeline ensure that the docs builds without warnings
+ - Add GitHub actions as another CI provider
+ - Validate internal meta schema in the tests
+
+**Dependencies**
+ - The following install dependencies have been added: `docutils`, `PyYAML` and
+   `sphinx`
+
+0.5.3 (2019-11-14)
+------------------
+
+**Improvements**
+ - Make sure all examples in the documentation is valid and run them in the
+   test suite
+
+0.5.2 (2019-08-30)
+------------------
+
+**Improvements**
+ - Various improvements to the documentation
+
+0.5.1 (2019-06-14)
+------------------
+
+**Improvements**
+ - Fix typos in the documentation
+
+0.5.0 (2019-06-13)
+------------------
+
+**New features**
+ - Support context validation for containers
+
+**Improvements**
+ - Allow for chaining `BooleanResults`, and hence transformations and validators
+
+0.4.2 (2019-05-19)
+------------------
+
+**Miscellaneous**
+ - Improve information in setup.py
+
+0.4.1 (2019-05-19)
+------------------
+
+**Bugfixes**
+ - Extractors are now passed to new suite when pushing layers
+
+**New features**
+ - Initial documentation written and hosted at read the docs
+
+**Miscellaneous**
+ - Minor code improvements
+
+0.4.0 (2019-05-07)
+------------------
+
+**New features**
+ - Support for context validation
+ - Support for layer transformations, transformations and context transformations
+
+**Improvements**
+ - Remove layer validation
+ - Accept unicode strings as strings
+ - No sorting of dict keys
+
+0.3.1 (2019-04-29)
+------------------
+
+**Bugfixes**
+ - Fix various errors regarding imports
+
+0.3.0 (2019-04-26)
+------------------
+
+**Bugfixes**
+ - Fix docs import in configsuite's init-file
+
+**New features**
+ - New basic types `Date` and `DateType`
+
+**Dependencies**
+ - Add six to Python 2 dependencies
+
+0.2.1 (2019-04-12)
+------------------
+
+**Bugfixes**
+ - Add description to meta schema
+
+**Miscellaneous**
+ - Various code improvements due to PyLint
+
+0.2.0 (2019-04-03)
+------------------
+
+**New features**
+ - Documentation generating capabilities from the specification
+ - Support for layered configurations
+
+0.1.0 (2018-11-08)
+------------------
+
+**New features**
+ - Initial validation and snapshot implementation
+ - Validation of schema
+ - Support for basic types: int, string, number and bool
+ - Support for containers: list, named_dict and dict
+ - Support for non-required dict keys

--- a/docs/source/user_guide/deprecated_behaviour.rst
+++ b/docs/source/user_guide/deprecated_behaviour.rst
@@ -1,0 +1,48 @@
+Deprecated behaviour
+====================
+
+Specifying AllowNone and Default
+--------------------------------
+
+In *Config Suite* 0.6 the schema keywords `AllowNone` and `Default` was
+introduced. `AllowNone` is used to indicate whether a basic element can take
+the value `None` and is defaulted to `False`. And `Default` can be used to
+provide default values for elements and it defaults to `None`. It should be
+noted that there is a strong correlation between `Default`, `AllowNone` and
+`Required`. In particular, the later can be deduced from the first two. In
+short, if an element is required it should neither allow `None` values nor have
+a default. Because if so, it would not be required.
+
+Here is a complete table of valid combinations of the three options:
+
+.. csv-table:: Valid combinations
+   :header: "AllowNone", "Default", "Required"
+   :widths: 20, 20, 20
+
+   "True", "True", "False"
+   "True", "False", "False"
+   "False", "True", "False"
+   "False", "False", "True"
+
+Required is deprecated
+----------------------
+In the transition to *Config Suite* 0.6 specifying elements in the schema as
+`Required` is deprecated. In particular, it is superseded as described above by
+specifying `AllowNone` and `Default`. The plan is that 0.6 will still
+function with `Required` in the schemas to ease the process of introducing
+`AllowNone` and `Default`. However, upon initialization `ConfigSuite` now
+accepts an optional, boolean argument named `deduce_required`. If
+`deduce_required` is set to `False` (which is the default value) a deprecation
+warning will be raised. After the transition to using `AllowNone` and `Default`
+has been made (which the reader is heavily encouraged to finish before
+considering the deprecation of `Required`) the consumer is expected to toggle
+`deduce_required` to  `True`. At this point a new deprecation warning will be
+raised upon creation of a `ConfigSuite` instance if the schema contains a
+`Required` specification. However, they are now all safe to remove and you are
+indeed encouraged to do so.
+
+Then in the 0.7 release `deduce_required` will default to `None`. If `True`
+is passed instead we will raise a deprecation warning and for any other value
+we will raise an exception. The idea is that in 0.7 you can safely stop
+setting `deduce_required` and then be ready for 0.8, where `deduce_required`
+will not be recognized as an optional argument anymore.

--- a/docs/source/user_guide/getting_started.rst
+++ b/docs/source/user_guide/getting_started.rst
@@ -517,14 +517,9 @@ also are invalid.
 Allow None
 ----------
 
-For certain configurations it may be reasonable for the user to provide
-``None`` as the value. The ``None`` is a specific value in the eyes of
-``ConfigSuite`` as it is also the value when a value hasn't been provided.
-As such, the schema must be specifically declared to allow the user to set
-``None`` in order for a configuration to be valid if it contains ``None``.
-
-The ``AllowNone`` type is only valid for ``BasicType``'s, not for containers.
-Setting ``AllowNone`` to ``True`` for anything but ``BasicType`` will result
+For certain configurations it may be reasonable to provide ``None`` as the
+value. The ``AllowNone`` type is only valid for ``BasicType``'s, not for
+containers.  Setting ``AllowNone`` for anything but ``BasicType`` will result
 in an invalid schema.
 
 Let us see how the owner section of the ``cars`` schema could be configured


### PR DESCRIPTION
Resolves: #99

The plan is to update the `dev` section of the release notes as development goes by and then turn it into the release notes for the next release when that release is ready. This process is exemplified in #138 