### PR TITLE
Add missing blank line in autogenerated RST output for dict.

### DIFF
--- a/configsuite/docs/__init__.py
+++ b/configsuite/docs/__init__.py
@@ -74,6 +74,7 @@ def generate(schema, level=0):
                 [
                     indent + "**<key>:**",
                     generate(schema[MK.Content][MK.Key], level=level + 2),
+                    "",
                     indent + "**<value>:**",
                     generate(schema[MK.Content][MK.Value], level=level + 2),
                 ]

--- a/tests/data/pets.py
+++ b/tests/data/pets.py
@@ -195,6 +195,7 @@ pet to better be able to find a matching pet owner.
             Name of the veterinary.
 
             :type: string
+
     **<value>:**
             Your score of the vet.
 


### PR DESCRIPTION
Dictionary RST output is missing blank line between the key and the value.