### PR TITLE
Provide exhaustive validator msg for allownone-required

### DIFF
--- a/configsuite/schema.py
+++ b/configsuite/schema.py
@@ -49,7 +49,8 @@ def _check_required_type(schema_level):
 
 
 @configsuite.validator_msg(
-    "A type is not required only if it allows None or have a non-None default"
+    "A schema element can be required if and only if the schema element does "
+    "not allow None as a value and defaults to None"
 )
 def _check_allownone_required(schema_level):
     if not isinstance(schema_level[MK.Type], types.BasicType):

--- a/tests/test_allow_none_vs_default.py
+++ b/tests/test_allow_none_vs_default.py
@@ -109,7 +109,7 @@ class TestNotAllowNoneVsDefault(unittest.TestCase):
 
         with self.assertRaises(ValueError) as error_context:
             configsuite.ConfigSuite({}, schema)
-        self.assertIn("A type is not required only if", str(error_context.exception))
+        self.assertIn("A schema element can be required", str(error_context.exception))
 
     def test_allow_none_default_required(self):
         schema = {
@@ -142,7 +142,7 @@ class TestNotAllowNoneVsDefault(unittest.TestCase):
 
         with self.assertRaises(ValueError) as error_context:
             configsuite.ConfigSuite({}, schema)
-        self.assertIn("A type is not required only if", str(error_context.exception))
+        self.assertIn("A schema element can be required", str(error_context.exception))
 
     def test_disallow_none_default_required(self):
         schema = {


### PR DESCRIPTION
The following example:

```
def schema():
    return {
        MK.Type: types.NamedDict,
        MK.Content: {
            "salary": {
                MK.Type: types.Number,
                MK.AllowNone: True,
            }
        }
    }

def config():
    return {"salary": 4}

config_suite = configsuite.ConfigSuite(config(), schema())
```

gives the following error message: `A type is not required only if it allows None or have a non-None default is false`

I am not sure it is apparent what the error really is, and to be frank I first thought it meant that it is not allowed to provide an `MK.Type`.

I've proposed a different error message. It could probably be improved, but at least it states what it does.

`A content can not be required and allow None, or unrequired and not allow None, unless it has a non-None default`