### PR TITLE
Support schema functions with default argument values

### DIFF
--- a/configsuite/extension/ext.py
+++ b/configsuite/extension/ext.py
@@ -188,14 +188,20 @@ class ConfigsuiteDocDirective(Directive):
             raise self.error(err_msg.format(func_name=func_str))
 
         insp = inspect_method(schema_func)  # pylint: disable=deprecated-method
-        if len(insp.args) != 0:
+        num_defaults = 0 if insp.defaults is None else len(insp.defaults)
+        if len(insp.args) > num_defaults:
             err_msg = (
                 "The module.function given at Configsuite :module: "
-                + "can not require any arguments, the '{func_name}' "
-                + "takes {num_args} argument(s)"
+                + "can not require any arguments without default value, "
+                + "the '{func_name}' takes {num_args} argument(s) and "
+                + "has {num_defaults} default value(s)."
             )
             raise self.error(
-                err_msg.format(func_name=func_str, num_args=len(insp.args))
+                err_msg.format(
+                    func_name=func_str,
+                    num_args=len(insp.args),
+                    num_defaults=num_defaults,
+                )
             )
 
         schema = schema_func()

--- a/tests/data/car.py
+++ b/tests/data/car.py
@@ -154,3 +154,10 @@ def build_config():
             {"location": "somewhere else", "casualties": 1},
         ],
     }
+
+
+def build_schema_with_default_arguments(_arg1=None, _arg2=42):
+    """Test function which has arguments, but only arguments
+    with default values.
+    """
+    return build_schema_with_validators_and_transformators()


### PR DESCRIPTION
If using the sphinx extension on functions with arguments, but which can be called without them (due to default arguments), the extension currently fail. Too strict? Relaxing requirement from `n_arguments > 0` to `n_arguments > n_defaults`.

